### PR TITLE
Add time formatter utility and Jest tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
   },
   "repository": {
     "type": "git",
@@ -13,6 +13,9 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
+  "devDependencies": {
+    "jest": "^29.7.0"
+  },
   "type": "commonjs",
   "bugs": {
     "url": "https://github.com/zhfengjing/remoteWorkTest/issues"

--- a/src/utils/formatter.js
+++ b/src/utils/formatter.js
@@ -1,0 +1,32 @@
+const padTwo = (value) => String(value).padStart(2, '0');
+
+const formatTime = (input) => {
+  const date = input instanceof Date ? input : new Date(input);
+
+  if (Number.isNaN(date.getTime())) {
+    throw new Error('Invalid date');
+  }
+
+  const now = new Date();
+  const isSameYear = date.getFullYear() === now.getFullYear();
+  const isSameDay =
+    isSameYear &&
+    date.getMonth() === now.getMonth() &&
+    date.getDate() === now.getDate();
+
+  if (isSameDay) {
+    return `${padTwo(date.getHours())}:${padTwo(date.getSeconds())}`;
+  }
+
+  if (isSameYear) {
+    return `${padTwo(date.getMonth() + 1)}/${padTwo(date.getDate())}`;
+  }
+
+  return `${date.getFullYear()}/${padTwo(date.getMonth() + 1)}/${padTwo(
+    date.getDate()
+  )}`;
+};
+
+module.exports = {
+  formatTime,
+};

--- a/src/utils/formatter.test.js
+++ b/src/utils/formatter.test.js
@@ -1,0 +1,28 @@
+const { formatTime } = require('./formatter');
+
+describe('formatTime', () => {
+  beforeAll(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2024-06-15T08:09:10Z'));
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  it('formats dates outside the current year as YYYY/MM/DD', () => {
+    expect(formatTime('2023-11-05T00:00:00Z')).toBe('2023/11/05');
+  });
+
+  it('formats dates within the current year as MM/DD', () => {
+    expect(formatTime('2024-04-02T00:00:00Z')).toBe('04/02');
+  });
+
+  it('formats today as HH:ss', () => {
+    expect(formatTime('2024-06-15T23:59:07Z')).toBe('23:07');
+  });
+
+  it('throws on invalid dates', () => {
+    expect(() => formatTime('invalid-date')).toThrow('Invalid date');
+  });
+});


### PR DESCRIPTION
### Motivation

- 提供一个时间格式化工具，按规则对时间进行友好展示：非当年返回 `YYYY/MM/DD`，当年返回 `MM/DD`，当天返回 `HH:ss`。
- 校验并防护非法时间输入以避免运行时错误。
- 为该工具添加单元测试以确保格式化规则在未来变更中保持正确性。

### Description

- 新增 `src/utils/formatter.js`，实现 `formatTime` 函数和内部辅助函数 `padTwo`，并对无效日期抛出 `Error('Invalid date')`。
- 新增 `src/utils/formatter.test.js`，使用 Jest 的假时钟 (`jest.useFakeTimers()` / `jest.setSystemTime()`) 覆盖非当年、当年、当天和非法输入四种场景。
- 更新 `package.json`，将 `test` 脚本设置为 `jest` 并在 `devDependencies` 中添加 `jest`。

### Testing

- 没有在本次变更中运行自动化测试。
- 单元测试已添加到 `src/utils/formatter.test.js` 并可通过运行 `npm test` 来执行。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961a10563448323903782a63c30f43a)