### PR TITLE
Add calculate helper and use in index

### DIFF
--- a/src/calculate.js
+++ b/src/calculate.js
@@ -1,0 +1,5 @@
+function calculate(a, b) {
+  return a * b;
+}
+
+module.exports = calculate;

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
-function sum(a, b) {
-  return a + b;
-}
+const calculate = require('./calculate');
+
+const result = calculate(5, 6);
+console.log(result);


### PR DESCRIPTION
### Motivation
- Introduce a small utility to compute the product of two numbers for use by the app entrypoint.
- Provide a concrete usage example by invoking the helper with the values `5` and `6` from the main file.

### Description
- Added `src/calculate.js` which exports `calculate(a, b)` that returns `a * b`.
- Updated `src/index.js` to `require('./calculate')`, call `calculate(5, 6)`, and `console.log` the result.
- Committed the changes with the message `Add calculate helper and use in index` and prepared PR content to merge into `main`.

### Testing
- No automated tests were run during this rollout.
- CI was not triggered because the changes were not pushed to a configured remote repository.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961c599bf9083238cbd9af0ea359eed)