### PR TITLE
Add basic Jest test for sum helper

### DIFF
--- a/__tests__/basic.test.js
+++ b/__tests__/basic.test.js
@@ -1,0 +1,7 @@
+const sum = require('../src/sum');
+
+describe('sum', () => {
+  it('adds two numbers', () => {
+    expect(sum(2, 3)).toBe(5);
+  });
+});


### PR DESCRIPTION
### Motivation
- Add a minimal Jest test to verify the test pipeline and confirm CI/test tooling is working.
- Keep changes minimal and do not modify existing source behavior while using Jest as the test runner.

### Description
- Add `__tests__/basic.test.js` which imports `sum` from `src/sum.js` and asserts that `sum(2, 3)` returns `5`.
- No changes were made to existing source files or to `package.json` beyond using the existing `npm test` script.

### Testing
- Ran `npm test` which executed the Jest suites and all tests passed.
- Test output:
```
npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.

> remoteworktest@1.0.0 test
> jest

PASS __tests__/basic.test.js
PASS utils/formatter.test.js

Test Suites: 2 passed, 2 total
Tests:       5 passed, 5 total
Snapshots:   0 total
Time:        1.545 s
Ran all test suites.
```

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696fabe154a88323baf43c0b98c1f587)